### PR TITLE
ZAUTHENTICATE not loaded during docker build

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -7,6 +7,7 @@
       <Packaging>module</Packaging>
       <SourcesRoot>src</SourcesRoot>
       <Resource Name="dc.Sample.PKG"/>
+      <Resource Name="ZAUTHENTICATE.mac"/>
       <Dependencies>
         <ModuleReference>
           <Name>swagger-ui</Name>


### PR DESCRIPTION
94.05 Exporting class: dc.Sample.SetupUtil
94.06 ERROR #6308: Item 'ZAUTHENTICATE.MAC' is invalid or does not have any data to export, skipping this item. 94.06 Errors detected during export.